### PR TITLE
✨ feat(app/services/markets/kaggle): 모델 total을 내부 ModelService로 정확화

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -53,7 +53,8 @@ router = APIRouter(tags=["models"])
         "| 필드 | 설명 |\n"
         "| --- | --- |\n"
         "| has_more | 다음 페이지가 있을 가능성을 나타냅니다. |\n"
-        "| total_is_exact | `total`이 정확한 전체 수인지 여부입니다. Kaggle은 `false`(하한값)입니다. |"
+        "| total_is_exact | `total`이 정확한 전체 수인지 여부입니다. 전체 수가 10000(Kaggle 상한)에 도달하면 `false`(하한값)입니다. |\n"
+        "| total_model_instances | (Kaggle 모델 전용) 모델의 파라미터별 변형 총 개수입니다. Kaggle 내부 API 조회 성공 시에만 포함됩니다. |"
     ),
     responses={
         200: {

--- a/app/services/markets/kaggle/async_kaggle_models.py
+++ b/app/services/markets/kaggle/async_kaggle_models.py
@@ -18,6 +18,10 @@ from app.services.markets.kaggle.handle import (
     parse_model_handle,
 )
 from app.services.markets.kaggle.kaggle_client import get_kaggle_client
+from app.services.markets.kaggle.internal_client import (
+    KAGGLE_TOTAL_CAP,
+    fetch_model_totals,
+)
 from app.services.markets.kaggle.mappers import (
     to_dataset_info_response,
     to_dataset_item,
@@ -124,18 +128,50 @@ class AsyncKaggleService:
         )
 
     @staticmethod
-    def _paginated_total(page: int, page_size: int, returned: int) -> Dict[str, Any]:
-        """Return best-effort pagination metadata.
+    def _paginated_total(
+        page: int,
+        page_size: int,
+        returned: int,
+        exact_total: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Return pagination metadata, preferring an upstream exact total.
 
-        Kaggle's list endpoints do not surface an upstream total, so we report a
-        lower bound (``(page-1)*page_size + len(items)``) and a ``has_more``
-        hint that's ``True`` whenever we got a full page back. Clients should
-        treat ``total`` as "at least this many" rather than an authoritative
-        count.
+        ``exact_total`` is the count from Kaggle (internal ``ModelService`` first,
+        public ``ModelApiService`` as fallback). Three cases:
+
+        * ``exact_total`` below the cap -> trusted exact count
+          (``total_is_exact=True``).
+        * ``exact_total`` at/above ``KAGGLE_TOTAL_CAP`` (10000) -> Kaggle caps the
+          count there, so it's a lower bound (``total_is_exact=False``,
+          ``has_more=True``).
+        * ``exact_total`` is ``None`` (datasets, or no count available) -> derive
+          a lower bound from the page position
+          (``(page-1)*page_size + len(items)``).
         """
         effective_page = max(1, page)
         effective_page_size = max(1, page_size)
         seen_so_far = (effective_page - 1) * effective_page_size + returned
+
+        if exact_total is not None:
+            total = int(exact_total)
+            if total < seen_so_far:
+                # Upstream total trails the items we've already paged through
+                # (e.g. an org-filtered count against an all-owners item list);
+                # report a lower bound rather than a number smaller than shown.
+                return {
+                    "total": seen_so_far,
+                    "total_is_exact": False,
+                    "has_more": returned >= effective_page_size,
+                }
+            if total >= KAGGLE_TOTAL_CAP:
+                # Kaggle ceilings the count at the cap; real total is higher.
+                return {"total": total, "total_is_exact": False, "has_more": True}
+            return {
+                "total": total,
+                "total_is_exact": True,
+                "has_more": seen_so_far < total,
+            }
+
         has_more = returned >= effective_page_size
         return {
             "total": seen_so_far,
@@ -147,8 +183,28 @@ class AsyncKaggleService:
     # Models
     # =============================================================================
 
-    def _model_list_sync(self, *, search: str, sort_by: str, page_size: int, page: int, owner: Optional[str] = None) -> List[Any]:
+    def _model_list_sync(self, *, search: str, sort_by: str, page_size: int, page: int, owner: Optional[str] = None) -> Dict[str, Any]:
+        """List one page of models as ``{"items": [...], "total": Optional[int]}``.
+
+        ``total`` is Kaggle's authoritative ``total_results`` count when the
+        installed SDK exposes the low-level client (so pagination can report an
+        exact total). It is ``None`` when only the high-level ``model_list``
+        helper is reachable, because that helper discards the upstream count;
+        the caller then derives a best-effort lower bound.
+        """
         api = get_kaggle_client()
+
+        low_level = self._model_list_lowlevel(
+            api,
+            search=search,
+            sort_by=sort_by,
+            page_size=page_size,
+            page=page,
+            owner=owner,
+        )
+        if low_level is not None:
+            return low_level
+
         kwargs: Dict[str, Any] = {
             "sort_by": sort_by,
             "page_size": page_size,
@@ -157,7 +213,7 @@ class AsyncKaggleService:
         if owner:
             kwargs["owner"] = owner
         try:
-            return self._call_sdk(
+            items = self._call_sdk(
                 api,
                 ["model_list", "models_list"],
                 **kwargs,
@@ -165,7 +221,68 @@ class AsyncKaggleService:
             )
         except TypeError:
             # Older SDKs don't accept page_token; fall back without it.
-            return self._call_sdk(api, ["model_list", "models_list"], **kwargs)
+            items = self._call_sdk(api, ["model_list", "models_list"], **kwargs)
+        return {"items": list(items or []), "total": None}
+
+    def _model_list_lowlevel(
+        self,
+        api: Any,
+        *,
+        search: str,
+        sort_by: str,
+        page_size: int,
+        page: int,
+        owner: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch a models page via the low-level kagglesdk client to read ``total_results``.
+
+        The high-level ``KaggleApi.model_list`` helper returns only the page
+        items and throws away the ``total_results`` count that the underlying
+        ``ListModels`` RPC returns. We replicate its request setup against the
+        low-level client so we can surface that exact total.
+
+        Returns ``{"items": [...], "total": int}`` on success, or ``None`` when
+        the installed SDK lacks the low-level surface (the caller then falls
+        back to the high-level helper). Genuine upstream errors (auth, network,
+        5xx) propagate so the router can map them to the right status code.
+        """
+        build_client = getattr(api, "build_kaggle_client", None)
+        if not callable(build_client):
+            return None
+        try:
+            from kagglesdk.models.types.model_api_service import ApiListModelsRequest
+            from kagglesdk.models.types.model_enums import ListModelsOrderBy
+        except ImportError:
+            return None
+
+        order_by = ListModelsOrderBy.LIST_MODELS_ORDER_BY_HOTNESS
+        valid = getattr(api, "valid_model_sort_bys", None)
+        if sort_by and (valid is None or sort_by in valid):
+            try:
+                order_by = api.lookup_enum(ListModelsOrderBy, order_by, sort_by)
+            except Exception:  # unknown sort key -> keep the hotness default
+                order_by = ListModelsOrderBy.LIST_MODELS_ORDER_BY_HOTNESS
+
+        request = ApiListModelsRequest()
+        request.sort_by = order_by
+        request.search = search or ""
+        request.owner = owner or ""
+        request.page_size = page_size
+        # Preserve the existing page->page_token mapping used by the high-level path.
+        if page and page > 1:
+            request.page_token = str(page)
+
+        with build_client() as kaggle:
+            client = getattr(getattr(kaggle, "models", None), "model_api_client", None)
+            list_models = getattr(client, "list_models", None)
+            if not callable(list_models):
+                return None
+            response = list_models(request)
+
+        if not hasattr(response, "total_results"):
+            return None
+        items = list(getattr(response, "models", None) or [])
+        return {"items": items, "total": int(getattr(response, "total_results", 0) or 0)}
 
     async def _list_models(
         self,
@@ -177,19 +294,52 @@ class AsyncKaggleService:
     ) -> Dict[str, Any]:
         sort_by = _MODEL_SORT_MAP.get(sort, "hotness")
         effective_limit = max(1, min(limit, 100))
-        raw_items = await self._call(
+        raw = await self._call(
             self._model_list_sync,
             search=query or "",
             sort_by=sort_by,
             page_size=effective_limit,
             page=max(1, page),
         )
-        items = list(raw_items or [])
+        items = list(raw.get("items") or [])
         models = [to_model_item(item) for item in items]
-        return {
+
+        # Primary count source: Kaggle's internal ModelService (accurate
+        # totalResults + variation count, matching kaggle.com/models). Falls
+        # back to the public SDK total_results (capped at 10000) when the
+        # internal call fails for any reason.
+        internal = await self._fetch_internal_total(query or "")
+        if internal is not None:
+            exact_total: Optional[int] = internal["total_results"]
+            total_instances: Optional[int] = internal["total_model_instances"]
+        else:
+            exact_total = raw.get("total")
+            total_instances = None
+
+        result: Dict[str, Any] = {
             "models": models,
-            **self._paginated_total(page, effective_limit, len(models)),
+            **self._paginated_total(
+                page, effective_limit, len(models), exact_total=exact_total
+            ),
         }
+        if total_instances is not None:
+            result["total_model_instances"] = total_instances
+        return result
+
+    async def _fetch_internal_total(self, search: str) -> Optional[Dict[str, int]]:
+        """Best-effort fetch of accurate model totals from Kaggle's internal API.
+
+        Returns ``None`` (so the caller falls back to the public total) on any
+        failure or timeout; ``fetch_model_totals`` itself never raises.
+        """
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(fetch_model_totals, search),
+                timeout=self._timeout,
+            )
+        except Exception as exc:
+            logger.warning("Internal Kaggle total fetch failed: %s", exc)
+            return None
 
     async def get_trending_models(
         self,

--- a/app/services/markets/kaggle/internal_client.py
+++ b/app/services/markets/kaggle/internal_client.py
@@ -1,0 +1,143 @@
+"""Best-effort client for Kaggle's internal ``ModelService.ListModels`` endpoint.
+
+The public kaggle SDK (``ModelApiService.ListModels``) caps ``total_results`` at
+10000 and exposes no model-instance count. Kaggle's web UI instead calls the
+*internal* ``models.ModelService/ListModels`` endpoint (``/api/i/...``), which
+returns the accurate ``totalResults`` (e.g. 546 organization models) and
+``totalModelInstances`` (e.g. 3499 variations) shown on kaggle.com/models.
+
+This module replicates that call with a self-built, XSRF-warmed ``requests``
+session authenticated by the same ``(username, key)`` Basic credentials the SDK
+uses. It is intentionally fail-soft: every error path returns ``None`` so the
+caller can fall back to the public SDK total. This is an *undocumented* endpoint
+and may change without notice; treat it as a best-effort enhancement, not a
+contract.
+"""
+import threading
+from typing import Dict, Optional
+
+import requests
+
+from app.core.config import settings
+from app.core.logging import logger
+
+_LIST_MODELS_URL = "https://www.kaggle.com/api/i/models.ModelService/ListModels"
+_WARM_URL = "https://www.kaggle.com/models"
+_XSRF_COOKIE_NAMES = ("XSRF-TOKEN", "CSRF-TOKEN")
+_XSRF_HEADER = "X-XSRF-TOKEN"
+
+# Kaggle caps ``totalResults`` at this value on BOTH the public and internal
+# endpoints; a value at the cap means "at least this many", not an exact count.
+KAGGLE_TOTAL_CAP = 10000
+
+# The web Models page lists organization-owned (published) models by default;
+# this filter reproduces the count it shows (e.g. 546 / 3499 variations).
+DEFAULT_OWNER_TYPE = "MODEL_OWNER_TYPE_ORGANIZATION"
+
+_session_lock = threading.Lock()
+_session: Optional[requests.Session] = None
+_xsrf_token: Optional[str] = None
+
+
+def _build_session():
+    """Create an authenticated session and warm up an XSRF token via a GET."""
+    sess = requests.Session()
+    sess.headers.update(
+        {
+            "User-Agent": "hub-connect/1.0",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+    sess.auth = (settings.KAGGLE_USERNAME, settings.KAGGLE_KEY)
+    resp = sess.get(_WARM_URL, timeout=settings.KAGGLE_TIMEOUT)
+    resp.raise_for_status()
+    token = None
+    for name in _XSRF_COOKIE_NAMES:
+        if name in sess.cookies:
+            token = sess.cookies.get(name)
+            break
+    return sess, token
+
+
+def _get_session(force: bool = False):
+    global _session, _xsrf_token
+    with _session_lock:
+        if force or _session is None:
+            _session, _xsrf_token = _build_session()
+        return _session, _xsrf_token
+
+
+def reset_internal_session() -> None:
+    """Drop the cached session/XSRF token. Recovery + test helper."""
+    global _session, _xsrf_token
+    with _session_lock:
+        _session = None
+        _xsrf_token = None
+
+
+def _build_body(search: str, owner_type: str) -> dict:
+    """Minimal-cost ListModels body: 1 item, smallest read mask, count only.
+
+    ``totalResults``/``totalModelInstances`` do not depend on ``pageSize`` or
+    ``orderBy``, so we ask for a single id-only record to keep the payload tiny.
+    """
+    return {
+        "filter": {
+            "id": [],
+            "tagIds": [],
+            "framework": "MODEL_FRAMEWORK_UNSPECIFIED",
+            "searchQuery": search or "",
+            "license": "UNSPECIFIED",
+            "minUsabilityRating": 0,
+            "datasetIds": [],
+            "ownerType": owner_type,
+        },
+        "orderBy": "LIST_MODELS_ORDER_BY_HOTNESS",
+        "pageSize": 1,
+        "pageToken": "",
+        "skip": 0,
+        "readMask": "id",
+        "privacyFilter": "PUBLIC",
+    }
+
+
+def fetch_model_totals(
+    search: str = "", *, owner_type: str = DEFAULT_OWNER_TYPE
+) -> Optional[Dict[str, int]]:
+    """Return ``{'total_results', 'total_model_instances'}`` or ``None`` on failure.
+
+    Never raises — callers treat ``None`` as "use the public SDK total instead".
+    Retries once with a fresh session in case a cached XSRF token went stale
+    (which surfaces as 400/401/403).
+    """
+    if not settings.KAGGLE_USERNAME or not settings.KAGGLE_KEY:
+        return None
+    body = _build_body(search, owner_type)
+    for attempt in (1, 2):
+        try:
+            sess, xsrf = _get_session(force=(attempt == 2))
+            headers = {_XSRF_HEADER: xsrf} if xsrf else {}
+            resp = sess.post(
+                _LIST_MODELS_URL, json=body, headers=headers, timeout=settings.KAGGLE_TIMEOUT
+            )
+            if resp.status_code in (400, 401, 403) and attempt == 1:
+                # Likely a stale XSRF token / expired session — rebuild and retry.
+                reset_internal_session()
+                continue
+            resp.raise_for_status()
+            data = resp.json()
+            total_results = data.get("totalResults")
+            if total_results is None:
+                return None
+            return {
+                "total_results": int(total_results),
+                "total_model_instances": int(data.get("totalModelInstances") or 0),
+            }
+        except Exception as exc:  # network/parse/etc. — fail soft to the caller
+            logger.warning("Kaggle internal model totals failed (attempt %s): %s", attempt, exc)
+            if attempt == 1:
+                reset_internal_session()
+                continue
+            return None
+    return None


### PR DESCRIPTION
공개 ModelApiService.ListModels가 total_results를 10000으로 캡하는 문제를 내부 비공식 엔드포인트(models.ModelService/ListModels)로 우회.

- internal_client.py 추가: 정확한 totalResults(예: 546)/totalModelInstances(3499) 조회. 독립 requests 세션 + Basic 인증 + XSRF 워밍, 세션·토큰 캐싱, 1회 재시도, 모든 오류 시 None 반환(절대 raise 안 함)
- _list_models: 내부 total 1차, 실패 시 공개 SDK total_results 2차 폴백
- _paginated_total: 10000(Kaggle 상한) 도달 시 total_is_exact=false(하한값) 처리
- 응답에 total_model_instances 필드 추가
- 항목 리스트는 downloadCount 보존(sort=downloads) 위해 공개 SDK 유지