### PR TITLE
🐛 S3 객체 다운로드 오류 수정

### DIFF
--- a/app/services/async_storage_service.py
+++ b/app/services/async_storage_service.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import time
 import uuid
-from email.utils import format_datetime
+from email.utils import formatdate
 from typing import List, Dict, Any
 
 import aiofiles
@@ -558,8 +558,10 @@ class AsyncStorageService:
             response = await self.s3_client.get_object(Bucket=bucket_name, Key=file_key)
 
             last_modified = response.get("LastModified", "")
-            if hasattr(last_modified, "tzinfo"):
-                last_modified = format_datetime(last_modified, usegmt=True)
+            if hasattr(last_modified, "timestamp"):
+                # botocore tags LastModified with dateutil tzutc(), which is != datetime.timezone.utc,
+                # so format_datetime(..., usegmt=True) would raise. formatdate(epoch) sidesteps tzinfo entirely.
+                last_modified = formatdate(last_modified.timestamp(), usegmt=True)
 
             metadata = {
                 "content_length": response["ContentLength"],
@@ -569,11 +571,11 @@ class AsyncStorageService:
             }
 
             async def _generate():
+                # aiobotocore StreamingBody.__aenter__ yields the raw aiohttp
+                # ClientResponse, whose .read() takes no size arg. Stream via the
+                # underlying StreamReader to avoid buffering the whole object.
                 async with response["Body"] as stream:
-                    while True:
-                        chunk = await stream.read(chunk_size)
-                        if not chunk:
-                            break
+                    async for chunk in stream.content.iter_chunked(chunk_size):
                         yield chunk
 
             return _generate(), metadata


### PR DESCRIPTION
## 개요
S3/Ceph 객체 다운로드에서 발생하던 500 오류와 0바이트 응답을 수정합니다.

## 변경
- `Last-Modified` 헤더 생성 시 `format_datetime(usegmt=True)`가 botocore의 `tzutc()` 타임존에서 `ValueError`를 던지던 문제 → `formatdate(timestamp, usegmt=True)`로 교체
- 스트리밍에서 aiobotocore Body의 `read(size)` 오용으로 본문이 0바이트로 전송되던 문제 → `content.iter_chunked()` 청크 스트리밍으로 교체

## 참고
- 원인은 앱 코드이며 Ceph 백엔드는 정상. 실제 Ceph로 다운로드 200 / 전체 바이트(PNG) 검증 완료.
- 운영 서버는 배포 후 재시작 필요.
